### PR TITLE
Commenting out setting of cxx standard to cxx-11.  

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(cellml
 generate_export_header(cellml EXPORT_FILE_NAME ${CELLML_EXPORT_H} BASE_NAME LIBCELLML)
 
 set_source_files_properties(${CELLML_EXPORT_H} PROPERTIES GENERATED TRUE)
-set_target_properties(cellml PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
+#set_target_properties(cellml PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
 
 export(TARGETS cellml FILE libcellml-exports.cmake)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,5 +33,5 @@ target_link_libraries(libcellmlTest cellml)
 # test executable.
 add_test(libcellmlTest libcellmlTest)
 
-set_target_properties(libcellmlTest PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
+#set_target_properties(libcellmlTest PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
Can be added back in when CMake version 3.2 is available.